### PR TITLE
Use recording name as download filename

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome",
+            "url": "https://example.com",
+            "runtimeArgs": [
+                "--load-extension=${workspaceFolder}/src"
+            ]
+        },
+        {
+            "type": "firefox",
+            "request": "launch",
+            "name": "Launch Firefox",
+            "url": "https://example.com",
+            "addonPath": "${workspaceFolder}/src"
+        }
+    ]
+}

--- a/src/background.js
+++ b/src/background.js
@@ -1,26 +1,27 @@
-chrome.runtime.onMessage.addListener(
-    function(request, sender, sendResponse) {
+// Listener used in the background to execute
+// commands passed by parameter from the extension
+chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
         if (request.fetchJson) {
-            let headers = {headers: {"Accept": "application/json, text/plain, */*"}};
-            if (request.password) {
-                headers.headers.accessPwd = request.password;
-            } else {
-                headers.headers.appFrom = "pb";
-            }
+            // Set the header used to fetch the JSON with the
+            // parameters passed by the main "process"
+            const headers = { headers: { "Accept": "application/json, text/plain, */*" } };
+            if (request.password) headers.headers.accessPwd = request.password;
+            else headers.headers.appFrom = "pb";
+
             fetch(request.fetchJson, headers)
                 .then(response => response.json())
                 .then(response => sendResponse(response))
-                .catch(exception => {
-                    sendResponse(null);
-                });
+                .catch(_exception => sendResponse(null));
             return true;
         }
+
         if (request.fetchText) {
             fetch(request.fetchText)
                 .then(response => response.text())
                 .then(response => sendResponse(response));
             return true;
         }
+
         if (request.safariOpenUrl) {
             chrome.tabs.create({url: request.safariOpenUrl});
         }
@@ -28,15 +29,19 @@ chrome.runtime.onMessage.addListener(
 );
 
 function reqWatcher(details) {
-    for (let i = 0; i < details.requestHeaders.length; i++) {
-        if (details.requestHeaders[i].name == "accessPwd") {
-            chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
-                chrome.tabs.sendMessage(tabs[0].id, {
-                    recPassword: details.requestHeaders[i].value
-                });
-            });
-            return;
-        }
+    // Find the detail containing the access password
+    const result = details.requestHeaders.filter((e) => e.name === "accessPwd");
+
+    if (result.length > 0) {
+        // The password exists
+        const password = result[0];
+
+        // Send the password to the the current tab
+        const callback = (tabs) => chrome.tabs.sendMessage(tabs[0].id, { recPassword: password.value });
+        chrome.tabs.query({
+            active: true,
+            currentWindow: true
+        }, callback);
     }
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -25,6 +25,13 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
         if (request.safariOpenUrl) {
             chrome.tabs.create({url: request.safariOpenUrl});
         }
+
+        if (request.downloadURL && request.savepath) {
+            chrome.downloads.download({
+                url: request.downloadURL,
+                filename: request.savepath
+            });
+        }
     }
 );
 

--- a/src/content.js
+++ b/src/content.js
@@ -35,6 +35,9 @@ function createDownloadButton(downloadURL) {
     return div;
 }
 
+/**
+ * Process a JSON-formatted response obtained from a WebEx page.
+ */
 function parseParametersFromResponse(response) {
     // Alias used to centralize response values
     const streamOption = response["mp4StreamOption"];

--- a/src/content.js
+++ b/src/content.js
@@ -102,34 +102,6 @@ function mutationCallback(_mutationArray, observer) {
     const loadingText = document.getElementsByClassName("el-loading-text")[0];
     if (!buttons.length || loadingText) return;
 
-    // Disconnect this observer to avoid
-    // triggering the DOM change detection event
-    observer.disconnect();
-
-    /**
-     * Add the download button to the video viewer bar.
-     * @param {string} text 
-     */
-    const addButton = (text) => {
-        // Extract the filename of the video
-        const parser = new window.DOMParser();
-        const data = parser.parseFromString(text, "text/xml");
-        const filename = data.getElementsByTagName("Sequence")[0].textContent;
-
-        // Set the recording name as the save name
-        const savename = `${params.recordName}.mp4`;
-
-        // Compose the download link of the video
-        const downloadURL = composeDownloadURL(params, filename);
-
-        // Create the download button
-        const downloadButton = createDownloadButton(downloadURL.toString(), savename);
-
-        // Get the buttons on the viewer bar and add the download button
-        const buttons = document.getElementsByClassName('buttonRightContainer');
-        buttons[0].prepend(downloadButton);
-    };
-
     chrome.runtime.sendMessage({
             fetchJson: API_URL,
             password: PASSWORD
@@ -138,22 +110,48 @@ function mutationCallback(_mutationArray, observer) {
             // Save the response from the page
             API_RESPONSE = response;
 
+            // Disconnect this observer to avoid
+            // triggering the DOM change detection event
+            observer.disconnect();
+
             // Get the useful parameters from the received response
             const params = parseParametersFromResponse(response);
 
             // Compose the URL from which to get the video stream to download
             const streamURL = composeStreamURL(params);
 
-            // Add the download button (first check for race condition)
-            const downloadButtonAlreadyPresent = document.getElementById('downloadButton') !== null;
-            if (!downloadButtonAlreadyPresent) {
-                chrome.runtime.sendMessage({
+            // Add the download button
+            chrome.runtime.sendMessage({
                     fetchText: streamURL.toString()
-                }, addButton);
-            }
+                },
+                (text) => addDownloadButtonToViewer(text, params));
         }
     )
 }
+
+/**
+ * Add the download button to the video viewer bar.
+ * @param {string} text 
+ */
+function addDownloadButtonToViewer(text, params) {
+    // Extract the filename of the video
+    const parser = new window.DOMParser();
+    const data = parser.parseFromString(text, "text/xml");
+    const filename = data.getElementsByTagName("Sequence")[0].textContent;
+
+    // Set the recording name as the save name
+    const savename = `${params.recordName}.mp4`;
+
+    // Compose the download link of the video
+    const downloadURL = composeDownloadURL(params, filename);
+    
+    // Create the download button
+    const downloadButton = createDownloadButton(downloadURL.toString(), savename);
+
+    // Get the buttons on the viewer bar and add the download button
+    const buttons = document.getElementsByClassName('buttonRightContainer');
+    buttons[0].prepend(downloadButton);
+};
 
 // Add a listener used to receive the password for the WebEx account
 chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {

--- a/src/content.js
+++ b/src/content.js
@@ -8,69 +8,135 @@ var API_URL = `https://${SUBDOMAIN}.webex.com/webappng/api/v1/recordings/${RECOR
 var PASSWORD;
 var API_RESPONSE = -1;
 
-if (AUTH_PARAMS) {
-    API_URL += AUTH_PARAMS;
+if (AUTH_PARAMS) API_URL += AUTH_PARAMS;
+
+/**
+ * Create the download button to add to the Webex video viewer.
+ * @param {string} downloadURL URL of the video to download.
+ */
+function createDownloadButton(downloadURL) {
+    // Create the button "container"
+    const div = document.createElement("div");
+    div.setAttribute("class", "buttonItem");
+
+    // Create the button
+    const i = document.createElement("i");
+    i.setAttribute("class", "icon-download");
+    i.setAttribute("title", "Download");
+    i.setAttribute("id", "downloadButton");
+    i.setAttribute("aria-label", "Download");
+    i.setAttribute("role", "button");
+
+    // Add the onClick event
+    i.addEventListener("click", () => window.location = downloadURL);
+
+    div.appendChild(i);
+
+    return div;
 }
 
-var observer = new MutationObserver(function(mutations) {
-    if (document.getElementsByClassName('buttonRightContainer').length) { // wait for this
+function parseParametersFromResponse(response) {
+    // Alias used to centralize response values
+    const streamOption = response["mp4StreamOption"];
 
-        let loadingText = document.getElementsByClassName("el-loading-text")[0];
-        if (loadingText) {
-            return; // will try again later
-        }
+    // Get the data we need to get the video stream
+    const host = streamOption["host"];
+    const recordingDir = streamOption["recordingDir"];
+    const timestamp = streamOption["timestamp"];
+    const token = streamOption["token"];
+    const xmlName = streamOption["xmlName"];
+    const playbackOption = streamOption["playbackOption"];
 
-        observer.disconnect();
-
-        var div = document.createElement("div");
-        div.setAttribute("class", "buttonItem");
-
-        var i = document.createElement("i");
-        i.setAttribute("class", "icon-download");
-        i.setAttribute("title", "Download");
-        i.setAttribute("id", "downloadButton");
-        i.setAttribute("aria-label", "Download");
-        i.setAttribute("role", "button");
-        div.appendChild(i);
-
-        chrome.runtime.sendMessage(
-            {fetchJson: API_URL, password: PASSWORD},
-            function(data) {
-                API_RESPONSE = data;
-                let host = data["mp4StreamOption"]["host"];
-                let recording_dir = data["mp4StreamOption"]["recordingDir"];
-                let timestamp = data["mp4StreamOption"]["timestamp"];
-                let token = data["mp4StreamOption"]["token"];
-                let xml_name = data["mp4StreamOption"]["xmlName"];
-                let playback_option = data["mp4StreamOption"]["playbackOption"];
-                chrome.runtime.sendMessage(
-                    {fetchText: `${host}/apis/html5-pipeline.do?recordingDir=${recording_dir}&timestamp=${timestamp}&token=${token}&xmlName=${xml_name}&isMobileOrTablet=false&ext=${playback_option}`},
-                    function(text) {
-                        let data = (new window.DOMParser()).parseFromString(text, "text/xml");
-                        let filename = data.getElementsByTagName("Sequence")[0].textContent;
-                        let mp4Url = `${host}/apis/download.do?recordingDir=${recording_dir}&timestamp=${timestamp}&token=${token}&fileName=${filename}`;
-                        i.addEventListener("click", function() {
-                            window.location = mp4Url;
-                        })
-                        var buttons = document.getElementsByClassName('buttonRightContainer');
-                        buttons[0].prepend(div);
-                    }
-                )
-            }
-        )
+    return {
+        host,
+        recordingDir,
+        timestamp,
+        token,
+        xmlName,
+        playbackOption
     }
+}
+
+function composeStreamURL(params) {
+    const url = new URL("apis/html5-pipeline.do", params.host);
+    url.searchParams.set("recordingDir", params.recordingDir);
+    url.searchParams.set("timestamp", params.timestamp);
+    url.searchParams.set("token", params.token);
+    url.searchParams.set("xmlName", params.xmlName);
+    url.searchParams.set("isMobileOrTablet", "false");
+    url.searchParams.set("ext", params.playbackOption);
+
+    return url;
+}
+
+function composeDownloadURL(params, filename) {
+    const url = new URL("apis/download.do", params.host);
+    url.searchParams.set("recordingDir", params.recordingDir);
+    url.searchParams.set("timestamp", params.timestamp);
+    url.searchParams.set("token", params.token);
+    url.searchParams.set("fileName", filename);
+
+    return url;
+}
+
+/**
+ * Callback used by a MutationObserver object in a
+ * WebEx page containing a registration to download.
+ */
+function mutationCallback(_mutationArray, observer) {
+    // Check if the change is the one we want and if the loading text is available.
+    // Otherwise it returns (fast fail)
+    const buttons = document.getElementsByClassName('buttonRightContainer'); // Buttons on the viewer bar
+    const loadingText = document.getElementsByClassName("el-loading-text")[0];
+    if (!buttons.length || loadingText) return;
+
+    chrome.runtime.sendMessage({
+            fetchJson: API_URL,
+            password: PASSWORD
+        },
+        (response) => {
+            API_RESPONSE = response;
+
+            // Get the useful parameters from the received response
+            const params = parseParametersFromResponse(response);
+
+            // Compose the URL from which to get the video stream to download
+            const streamURL = composeStreamURL(params);
+
+            chrome.runtime.sendMessage({ fetchText: streamURL.toString() },
+                (text) => {
+                    // Extract the filename of the video
+                    const parser = new window.DOMParser();
+                    const data = parser.parseFromString(text, "text/xml");
+                    const filename = data.getElementsByTagName("Sequence")[0].textContent;
+
+                    // Compose the download link of the video
+                    const downloadURL = composeDownloadURL(params, filename);
+                    
+                    // Create the download button
+                    const downloadButton = createDownloadButton(downloadURL.toString());
+
+                    // Disconnect this observer to avoid
+                    // triggering the DOM change detection event
+                    observer.disconnect();
+                    
+                    // Get the buttons on the viewer bar and add the download button
+                    const buttons = document.getElementsByClassName('buttonRightContainer');
+                    buttons[0].prepend(downloadButton);
+                }
+            )
+        }
+    )
+}
+
+// Add a listener used to receive the password for the WebEx account
+chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
+    if (request.recPassword) PASSWORD = request.recPassword;
+    if (request.apiResponse) sendResponse(API_RESPONSE);
 });
 
-chrome.runtime.onMessage.addListener(
-    function(request, sender, sendResponse) {
-        if (request.recPassword) {
-            PASSWORD = request.recPassword;
-        }
-        if (request.apiResponse) {
-            sendResponse(API_RESPONSE);
-        }
-    }
-);
+// Create an observer for the DOM
+const observer = new MutationObserver(mutationCallback);
 
 observer.observe(document.body, {
     childList: true,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,6 +2,7 @@
   "description": "Enables downloading of Webex meeting recordings",
   "version": "1.2.2",
   "permissions": [
+    "downloads",
     "storage",
     "tabs",
     "webRequest",

--- a/src/popup.html
+++ b/src/popup.html
@@ -98,11 +98,9 @@
                 <li>If you are using incognito mode, try with a normal browser window instead</li>
             </ul>
             <br>
-            <div id="error-container">
-                The following exception was raised:
-                <br>
-                <code id="error-message"></code>
-            </div>
+            <div>The following exception was raised:</div>
+            <br>
+            <code id="error-message"></code>
         </div>
         <div id="loading">
             <div class="title">Loading</div>

--- a/src/popup.html
+++ b/src/popup.html
@@ -97,6 +97,8 @@
                 <li>Refresh and try again; sometimes it just works</li>
                 <li>If you are using incognito mode, try with a normal browser window instead</li>
             </ul>
+            <br>
+            <div id="error-message"></div>
         </div>
         <div id="loading">
             <div class="title">Loading</div>

--- a/src/popup.html
+++ b/src/popup.html
@@ -98,7 +98,11 @@
                 <li>If you are using incognito mode, try with a normal browser window instead</li>
             </ul>
             <br>
-            <div id="error-message"></div>
+            <div id="error-container">
+                The following exception was raised:
+                <br>
+                <code id="error-message"></code>
+            </div>
         </div>
         <div id="loading">
             <div class="title">Loading</div>

--- a/src/popup.js
+++ b/src/popup.js
@@ -214,5 +214,6 @@ function callback(tabs) {
     });
 }
 
+// Get the currently focused tab
 const query = { active: true, currentWindow: true };
 chrome.tabs.query(query, callback);

--- a/src/popup.js
+++ b/src/popup.js
@@ -57,6 +57,7 @@ function renderException(exception) {
     document.body.classList.add("fail");
     document.getElementById("loading").style.display = "none";
     document.getElementById("fail").style.display = "block";
+    document.getElementById("error-message").textContent = exception.message;
 }
 
 /**
@@ -149,7 +150,7 @@ function checkResponseForErrors(response) {
         renderFailure();
         validResponse = false;
     } else if (!response) {
-        renderException(null);
+        renderException(new Error("Received null response"));
         validResponse = false;
     }
 
@@ -180,7 +181,7 @@ function callback(tabs) {
 
         // Compose the URL from which to get the video stream to download
         const streamURL = composeStreamURL(params);
-
+        
         fetch(streamURL.toString())
             .then(response => response.text())
             .then(text => (new window.DOMParser()).parseFromString(text, "text/xml"))

--- a/src/popup.js
+++ b/src/popup.js
@@ -186,8 +186,10 @@ function callback(tabs) {
             .then(response => response.text())
             .then(text => (new window.DOMParser()).parseFromString(text, "text/xml"))
             .then(data => {
+                // Convert from HTMLCollection to array
+                const messages = [...data.getElementsByTagName("Message")];
+
                 // Parse the messages in the chat
-                const messages = data.getElementsByTagName("Message");
                 const chat = messages.map((message) => {
                     // First get the HTML Elements
                     const datetimeElement = message.getElementsByTagName("DateTimeUTC");

--- a/src/popup.js
+++ b/src/popup.js
@@ -207,7 +207,7 @@ function callback(tabs) {
                 // Compse the captions URL
                 const filename = data.getElementsByTagName("Sequence")[0].textContent;
                 const meetingName = response["recordName"];
-                const hlsUrl = `${host}/hls-vod/recordingDir/${params.recordingDir}/timestamp/${params.timestamp}/token/${params.token}/fileName/${filename}.m3u8`;
+                const hlsUrl = `${params.host}/hls-vod/recordingDir/${params.recordingDir}/timestamp/${params.timestamp}/token/${params.token}/fileName/${filename}.m3u8`;
                 renderSuccess(meetingName, hlsUrl, chat);
             })
             .catch(ex => renderException(ex));

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,4 +1,5 @@
 const REGEX = /^https?:\/\/(.+?)\.webex\.com\/(?:recordingservice|webappng)\/sites\/([^\/]+)\/.*?([a-f0-9]{32})/g;
+const UPDATE_URL = "https://api.github.com/repos/jacopo-j/webxdownloader/releases/latest";
 
 function copyLink() {
     let text = document.getElementById("content");
@@ -58,93 +59,157 @@ function renderException(exception) {
     document.getElementById("fail").style.display = "block";
 }
 
+/**
+ * Check for updates for this extension.
+ */
 function checkUpdates() {
-    fetch("https://api.github.com/repos/jacopo-j/webxdownloader/releases/latest")
+    fetch(UPDATE_URL)
         .then(response => response.json())
         .then(data => {
-            let latestVersion = data.tag_name;
-            let currentVersion = chrome.runtime.getManifest().version;
+            // Get latest and current version for the extension
+            const latestVersion = data.tag_name;
+            const currentVersion = chrome.runtime.getManifest().version;
+
             if (latestVersion && latestVersion != currentVersion) {
+                // Show update link if update is available
                 document.getElementById("updates-available").style.display = "block";
+
+                // Open update link in safari browser
                 if (navigator.userAgent.indexOf("Safari") > -1) {
-                    document.getElementById("updates-link").addEventListener("click", (event) => {
-                        chrome.runtime.sendMessage({
-                            safariOpenUrl: document.getElementById("updates-link").getAttribute("href")
-                        });
+                    const updateButton = document.getElementById("updates-link");
+                    updateButton.addEventListener("click", (_event) => {
+                        const url = document.getElementById("updates-link").getAttribute("href");
+                        chrome.runtime.sendMessage({ safariOpenUrl: url });
                     });
                 }
             }
         })
 }
 
+/**
+ * Given a time value in absolute number of seconds,
+ * it returns a string in the format `HH:mm:ss`.
+ * @param {number} absTime
+ */
 function timeCode(absTime) {
-    let date = new Date(parseInt(absTime));
-    let hour = ("0" + date.getHours()).slice(-2);
-    let minute = ("0" + date.getMinutes()).slice(-2);
-    let second = ("0" + date.getSeconds()).slice(-2);
+    const date = new Date(parseInt(absTime));
+    const hour = ("0" + date.getHours()).slice(-2);
+    const minute = ("0" + date.getMinutes()).slice(-2);
+    const second = ("0" + date.getSeconds()).slice(-2);
     return `${hour}:${minute}:${second}`;
 }
 
-function callback(tabs) {
-    checkUpdates();
-    var url = tabs[0].url;
-    let match = REGEX.exec(url);
-    if (! match) {
-        renderFailure();
-        return;
+/**
+ * Process a JSON-formatted response obtained from a WebEx page.
+ */
+function parseParametersFromResponse(response) {
+    // Alias used to centralize response values
+    const streamOption = response["mp4StreamOption"];
+
+    // Get the data we need to get the video stream
+    const host = streamOption["host"];
+    const recordingDir = streamOption["recordingDir"];
+    const timestamp = streamOption["timestamp"];
+    const token = streamOption["token"];
+    const xmlName = streamOption["xmlName"];
+    const playbackOption = streamOption["playbackOption"];
+
+    return {
+        host,
+        recordingDir,
+        timestamp,
+        token,
+        xmlName,
+        playbackOption
     }
+}
+
+function composeStreamURL(params) {
+    const url = new URL("apis/html5-pipeline.do", params.host);
+    url.searchParams.set("recordingDir", params.recordingDir);
+    url.searchParams.set("timestamp", params.timestamp);
+    url.searchParams.set("token", params.token);
+    url.searchParams.set("xmlName", params.xmlName);
+    url.searchParams.set("isMobileOrTablet", "false");
+    url.searchParams.set("ext", params.playbackOption);
+
+    return url;
+}
+
+function checkResponseForErrors(response) {
+    let validResponse = true;
+
+    if (chrome.runtime.lastError) {
+        console.log(chrome.runtime.lastError);
+        renderFailure();
+        validResponse = false;
+    }
+
+    if (response == -1) {
+        renderFailure();
+        validResponse = false;
+    } else if (!response) {
+        renderException(null);
+        validResponse = false;
+    }
+
+    return validResponse;
+}
+
+function isThisAWebExPage(url) {
+    const match = REGEX.exec(url);
+    if (!match) renderFailure();
+    return match !== null;
+}
+
+function callback(tabs) {
+    // Check for extension update
+    checkUpdates();
+
+    // Check if this URL is of a WebEx page
+    if(!isThisAWebExPage(tabs[0].url)) return;
+    
     chrome.tabs.sendMessage(tabs[0].id, {
-        apiResponse: true
-    }, (data) => {
-        if (chrome.runtime.lastError) {
-            console.log(chrome.runtime.lastError);
-            renderFailure();
-            return;
-        }
-        if (data == -1) {
-            renderFailure();
-            return;
-        } else if (! data) {
-            renderException(null);
-            return;
-        }
-        try {
-            let host = data["mp4StreamOption"]["host"];
-            let recording_dir = data["mp4StreamOption"]["recordingDir"];
-            let timestamp = data["mp4StreamOption"]["timestamp"];
-            let token = data["mp4StreamOption"]["token"];
-            let xml_name = data["mp4StreamOption"]["xmlName"];
-            let playback_option = data["mp4StreamOption"]["playbackOption"];
-            let meeting_name = data["recordName"];
-            fetch(`${host}/apis/html5-pipeline.do?recordingDir=${recording_dir}&timestamp=${timestamp}&token=${token}&xmlName=${xml_name}&isMobileOrTablet=false&ext=${playback_option}`)
-                .then(response => response.text())
-                .then(text => (new window.DOMParser()).parseFromString(text, "text/xml"))
-                .then(data => {
-                    let filename = data.getElementsByTagName("Sequence")[0].textContent;
-                    let messages = data.getElementsByTagName("Message");
-                    let chat = [];
-                    for (let i = 0; i < messages.length; i++) {
-                        try {
-                            chat.push({
-                                "timecode": timeCode(messages[i].getElementsByTagName("DateTimeUTC")[0].textContent),
-                                "name": messages[i].getElementsByTagName("LoginName")[0].textContent,
-                                "message": messages[i].getElementsByTagName("Content")[0].textContent
-                            });
-                        } catch(exception) {
-                            continue;
-                        }
-                    }
-                    let hlsUrl = `${host}/hls-vod/recordingDir/${recording_dir}/timestamp/${timestamp}/token/${token}/fileName/${filename}.m3u8`;
-                    renderSuccess(meeting_name, hlsUrl, chat);
-                })
-                .catch(exception => {
-                    renderException(exception);
+                apiResponse: true
+            }, (response) => {
+        // Check if the response is valid
+        if(!checkResponseForErrors(response)) return;
+        
+        // Get the useful parameters from the received response
+        const params = parseParametersFromResponse(response);
+
+        // Compose the URL from which to get the video stream to download
+        const streamURL = composeStreamURL(params);
+
+        fetch(streamURL.toString())
+            .then(response => response.text())
+            .then(text => (new window.DOMParser()).parseFromString(text, "text/xml"))
+            .then(data => {
+                // Parse the messages in the chat
+                const messages = data.getElementsByTagName("Message");
+                const chat = messages.map((message) => {
+                    // First get the HTML Elements
+                    const datetimeElement = message.getElementsByTagName("DateTimeUTC");
+                    const nameElement = message.getElementsByTagName("LoginName");
+                    const messageElement = message.getElementsByTagName("Content");
+
+                    // Check the existence of the data
+                    return {
+                        "timecode": datetimeElement.length > 0 ? timeCode(datetimeElement[0].textContent) : "00:00:00",
+                        "name": nameElement.length > 0 ? nameElement[0].textContent : "Name unavailable",
+                        "message": messageElement.length > 0 ? messageElement[0].textContent : "Message unavailable",
+                    };
                 });
-        } catch (exception) {
-            renderException(exception);
-        }
+
+                // Compse the captions URL
+                const filename = data.getElementsByTagName("Sequence")[0].textContent;
+                const meetingName = response["recordName"];
+                const hlsUrl = `${host}/hls-vod/recordingDir/${params.recordingDir}/timestamp/${params.timestamp}/token/${params.token}/fileName/${filename}.m3u8`;
+                renderSuccess(meetingName, hlsUrl, chat);
+            })
+            .catch(ex => renderException(ex));
     });
 }
 
-var query = {active: true, currentWindow: true};
+const query = { active: true, currentWindow: true };
 chrome.tabs.query(query, callback);


### PR DESCRIPTION
Fix #8

This pull request allows to use the recording title as the name of the video to download instead of "merge_[...].mp4".

The code is also refactored to reduce cyclomatic complexity and debugging support for Visual Studio Code is added.
