### PR TITLE
Fix MutationObserver for the new player

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -11,33 +11,29 @@ var API_RESPONSE = -1;
 if (AUTH_PARAMS) API_URL += AUTH_PARAMS;
 
 /**
- * Create the download button to add to the Webex video viewer.
+ * Create the download button to add to the Webex video page.
  * @param {string} downloadURL URL of the video to download.
  * @param {string} savepath Path where save the recording.
  */
 function createDownloadButton(downloadURL, savepath) {
-    // Create the button "container"
-    const div = document.createElement("div");
-    div.setAttribute("class", "buttonItem");
-
     // Create the button
     const i = document.createElement("i");
-    i.setAttribute("class", "icon-download");
     i.setAttribute("title", "Download");
-    i.setAttribute("id", "downloadButton");
-    i.setAttribute("aria-label", "Download");
+    i.setAttribute("tabindex", "0")
     i.setAttribute("role", "button");
+    i.setAttribute("id", "playerDownload");
+    i.setAttribute("aria-label", `Download recording: ${savepath}`);
+    i.classList.add("icon-download", "recordingDownload");
 
-    // Add the onClick event
+    // Add the onClick and onKeyPress events
     const downloadMessage = {
         downloadURL: downloadURL,
         savepath: savepath
     };
     i.addEventListener("click", () => chrome.runtime.sendMessage(downloadMessage));
+    i.addEventListener("keypress", () => chrome.runtime.sendMessage(downloadMessage));
 
-    div.appendChild(i);
-
-    return div;
+    return i;
 }
 
 /**
@@ -101,11 +97,14 @@ function sanitizeFilename(filename) {
  * WebEx page containing a registration to download.
  */
 function mutationCallback(_mutationArray, observer) {
-    // Check if the change is the one we want and if the loading text is available.
+    // Check if the change is the one we want
     // Otherwise it returns (fast fail)
-    const buttons = document.getElementsByClassName('buttonRightContainer'); // Buttons on the viewer bar
-    const loadingText = document.getElementsByClassName("el-loading-text")[0];
-    if (!buttons.length || loadingText) return;
+    const playButtons = document.getElementsByClassName("recordingTitle"); // Recording title
+    if (!playButtons.length) return;
+
+    // Disconnect this observer to avoid
+    // triggering the DOM change detection event
+    observer.disconnect();
 
     chrome.runtime.sendMessage({
             fetchJson: API_URL,
@@ -114,10 +113,6 @@ function mutationCallback(_mutationArray, observer) {
         (response) => {
             // Save the response from the page
             API_RESPONSE = response;
-
-            // Disconnect this observer to avoid
-            // triggering the DOM change detection event
-            observer.disconnect();
 
             // Get the useful parameters from the received response
             const params = parseParametersFromResponse(response);
@@ -129,7 +124,7 @@ function mutationCallback(_mutationArray, observer) {
             chrome.runtime.sendMessage({
                     fetchText: streamURL.toString()
                 },
-                (text) => addDownloadButtonToViewer(text, params));
+                (text) => addDownloadButtonToPage(text, params));
         }
     )
 }
@@ -138,7 +133,11 @@ function mutationCallback(_mutationArray, observer) {
  * Add the download button to the video viewer bar.
  * @param {string} text 
  */
-function addDownloadButtonToViewer(text, params) {
+function addDownloadButtonToPage(text, params) {
+    // Do not add the button if already present
+    const downloadButtons = document.getElementsByClassName("icon-download")
+    if (downloadButtons.length) return;
+
     // Extract the filename of the video
     const parser = new window.DOMParser();
     const data = parser.parseFromString(text, "text/xml");
@@ -154,8 +153,8 @@ function addDownloadButtonToViewer(text, params) {
     const downloadButton = createDownloadButton(downloadURL.toString(), savename);
 
     // Get the buttons on the viewer bar and add the download button
-    const buttons = document.getElementsByClassName('buttonRightContainer');
-    buttons[0].prepend(downloadButton);
+    const titleDivs = document.getElementsByClassName('recordingHeader');
+    titleDivs[0].appendChild(downloadButton);
 };
 
 // Add a listener used to receive the password for the WebEx account


### PR DESCRIPTION
The MutationObserver was looking for elements that are never created inside the new player page.
The download button is inserted beside the recording title, as it happens in a recording with the download button regularly enabled. The new video player does not seem to show any download button.
I tested with a random Polimi recording and with the one written in #14, on both Firefox and Chromium.
Should fix #13.