### PR TITLE
Update XML endpoint for new recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Download the `.xpi` file from the [latest release](https://github.com/jacopo-j/W
 * Browse to `chrome://extensions`
 * Turn on "Developer mode" on the top right
 * Click "Load unpacked extension..." on the top left
-* Select the folder to which your zip file was extracted.
+* Select the folder named `src` from the folder to which your zip file was extracted.
 
 ### Safari (experimental)
 

--- a/src/content.js
+++ b/src/content.js
@@ -71,18 +71,6 @@ function parseParametersFromResponse(response) {
     }
 }
 
-function composeStreamURL(params) {
-    const url = new URL("apis/html5-pipeline.do", params.host);
-    url.searchParams.set("recordingDir", params.recordingDir);
-    url.searchParams.set("timestamp", params.timestamp);
-    url.searchParams.set("token", params.token);
-    url.searchParams.set("xmlName", params.xmlName);
-    url.searchParams.set("isMobileOrTablet", "false");
-    url.searchParams.set("ext", params.playbackOption);
-
-    return url;
-}
-
 function sanitizeFilename(filename) {
     const allowedChars = /[^\w\s\d\-_~,;\[\]\(\).]/g;
     return filename.replaceAll(allowedChars, "_");
@@ -113,31 +101,21 @@ function mutationCallback(_mutationArray, observer) {
             // Get the useful parameters from the received response
             const params = parseParametersFromResponse(response);
 
-            // Compose the URL from which to get the video stream to download
-            const streamURL = composeStreamURL(params);
-
             // Add the download button
-            chrome.runtime.sendMessage({
-                    fetchText: streamURL.toString()
-                },
-                (text) => addDownloadButtonToPage(text, params));
+            addDownloadButtonToPage(params);
         }
     )
 }
 
 /**
  * Add the download button to the video viewer bar.
- * @param {string} text
+ * @param {Object} params
  */
-function addDownloadButtonToPage(text, params) {
+function addDownloadButtonToPage(params) {
     // Do not add the button if already present
     const downloadButtons = document.getElementsByClassName("icon-download")
     if (downloadButtons.length) return;
 
-    // Extract the filename of the video
-    const parser = new window.DOMParser();
-    const data = parser.parseFromString(text, "text/xml");
-    const filename = data.getElementsByTagName("Sequence")[0].textContent;
 
     // Set the recording name as the save name
     const savename = `${sanitizeFilename(params.recordName)}.mp4`;

--- a/src/popup.js
+++ b/src/popup.js
@@ -140,7 +140,7 @@ function parseParametersFromResponse(response) {
 
 function composeStreamURL(params) {
     // Recordings before May 2022
-    if ("recordingDir" in params) {
+    if (params["recordingDir"] !== undefined) {
         const url = new URL("apis/html5-pipeline.do", params.host);
         url.searchParams.set("recordingDir", params.recordingDir);
         url.searchParams.set("timestamp", params.timestamp);
@@ -152,7 +152,7 @@ function composeStreamURL(params) {
         return url;
     }
     // Recordings from May 2022
-    else if ("siteid" in params) {
+    else if (params["siteid"] !== undefined) {
         const url = new URL("nbr/MultiThreadDownloadServlet/recording.xml", params.host);
         url.searchParams.set("siteid", params.siteid);
         url.searchParams.set("recordid", params.recordid);


### PR DESCRIPTION
New recordings (approximately from May 2022, I don't have an exact date) have different stream parameters, use a new XML endpoint for the chat and have a new location for the HLS URL.

This PR adjusts the extension to work with the new version.
Some useless code was also removed from `content.js`, as it was just breaking the extension due to the new updates and was not really used: an XML was used just to get a filename, that in turn was not used anywhere.

Tested on an old recording, on a recent one from my organization and on the one provided in #17 .

Fixes #17 